### PR TITLE
Fix res_list memory leak and align evaluation inputs

### DIFF
--- a/multiagentsimulation.py
+++ b/multiagentsimulation.py
@@ -340,13 +340,14 @@ def run_multi_agent_simulation(num=50): # Added num parameter
 
             resurrected_population = []
             for agent_to_res in res_list: # Resurrect 'num' agents
-                
-                
+
+
                 # Apply mutation to this new agent to create variation
                 # Using stronger mutation to encourage more exploration when resurrecting
                 resurrected_agent = mutate_agent(agent_to_res, MUTATION_RATE, MUTATION_STRENGTH)
                 resurrected_population.append(resurrected_agent)
 
+            res_list.clear()  # Clear references to dead agents once used
             population = resurrected_population
 
             # Regenerate the world for the new generation


### PR DESCRIPTION
## Summary
- use local tile input logic in `AgentEvaluation` to match the training loop
- clear `res_list` after resurrecting agents so dead agents aren't retained in memory

## Testing
- `python -m py_compile AgentEvaluation.py multiagentsimulation.py`

------
https://chatgpt.com/codex/tasks/task_e_684f383b6854832b8c6eefda8f0d2b39