### PR TITLE
Add terrain smoothing to keep world traversable

### DIFF
--- a/GravityWorld.py
+++ b/GravityWorld.py
@@ -188,3 +188,23 @@ class GravityWorld:
                 render_grid[ay-1][ax] = Tile.BLOCK
 
         return render_grid
+
+    def column_surface_height(self, x):
+        """Return the y-coordinate of the topmost block in column ``x``."""
+        for y in range(self.height - 2, -1, -1):
+            if self.grid[y][x] == Tile.BLOCK:
+                return y
+        return self.height - 1
+
+    def enforce_traversable(self):
+        """Ensure adjacent columns differ in height by at most one block."""
+        for x in range(self.width - 1):
+            while True:
+                h_cur = self.column_surface_height(x)
+                h_next = self.column_surface_height(x + 1)
+                if h_cur - h_next > 1:
+                    self.place_tile(x, h_cur, Tile.EMPTY)
+                elif h_next - h_cur > 1:
+                    self.place_tile(x + 1, h_next, Tile.EMPTY)
+                else:
+                    break

--- a/multiagentsimulation.py
+++ b/multiagentsimulation.py
@@ -218,6 +218,7 @@ def run_multi_agent_simulation(num=50):
             world = new_world
             current_width = new_width
             current_height = new_height
+            world.enforce_traversable()
             place_agents_in_world(world, population)
 
         # Terrain evolution
@@ -241,6 +242,7 @@ def run_multi_agent_simulation(num=50):
                             world.place_tile(x, target_y, Tile.BLOCK)
                         elif direction == -1 and world.get_tile(x, column_height) == Tile.BLOCK:
                             world.place_tile(x, column_height, Tile.EMPTY)
+            world.enforce_traversable()
 
         proba = (NUM_SIMULATION_STEPS - step) / NUM_SIMULATION_STEPS
         proba = np.max([proba, .2])
@@ -300,6 +302,7 @@ def run_multi_agent_simulation(num=50):
 
         current_agent_positions_on_grid = [(a.position[0], a.position[1]) for a in population if a.energy > 0 and a.position is not None]
         updated_agent_positions, updated_food_positions = world.apply_gravity(current_agent_positions_on_grid, active_food_positions)
+        world.enforce_traversable()
 
         agent_index = 0
         for agent in population:


### PR DESCRIPTION
## Summary
- add utilities in `GravityWorld` for checking terrain heights
- enforce at most one-block height difference across adjacent columns
- call `world.enforce_traversable()` after expansions, terrain updates, and gravity

## Testing
- `python -m py_compile GravityWorld.py multiagentsimulation.py Agent.py`

------
https://chatgpt.com/codex/tasks/task_e_685025d48c40832bb0e304648a0890e8