### PR TITLE
Fix terrain traversability enforcement

### DIFF
--- a/GravityWorld.py
+++ b/GravityWorld.py
@@ -202,9 +202,15 @@ class GravityWorld:
             while True:
                 h_cur = self.column_surface_height(x)
                 h_next = self.column_surface_height(x + 1)
-                if h_cur - h_next > 1:
-                    self.place_tile(x, h_cur, Tile.EMPTY)
-                elif h_next - h_cur > 1:
-                    self.place_tile(x + 1, h_next, Tile.EMPTY)
+                if h_cur < h_next - 1:
+                    if h_cur < self.height - 1:
+                        self.place_tile(x, h_cur, Tile.EMPTY)
+                    else:
+                        break
+                elif h_next < h_cur - 1:
+                    if h_next < self.height - 1:
+                        self.place_tile(x + 1, h_next, Tile.EMPTY)
+                    else:
+                        break
                 else:
                     break


### PR DESCRIPTION
## Summary
- ensure that `GravityWorld.enforce_traversable` removes blocks from the taller column
- prevent infinite loops when a bottom block is missing

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_6851647ebf74832b8e20ca6fbb02df31